### PR TITLE
Added Redhat Support

### DIFF
--- a/cert/map.jinja
+++ b/cert/map.jinja
@@ -34,5 +34,15 @@
         'cert_mode': 644,
         'key_mode': 640,
     },
+    'RedHat': {
+        'cert_dir': '/etc/pki/tls/certs',
+        'key_dir': '/etc/pki/tls/private',
+        'pkgs': [ 'ca-certificates' ],
+        'cert_user': 'root',
+        'key_user': 'root',
+        'cert_group': 'root',
+        'key_group': 'ssl-cert',
+        'cert_mode': 644,
+        'key_mode': 640,
 
 }, grain='os', merge=salt['pillar.get']('cert:lookup')) %}

--- a/cert/map.jinja
+++ b/cert/map.jinja
@@ -23,17 +23,6 @@
         'cert_mode': 644,
         'key_mode': 640,
     },
-    'Ubuntu': {
-        'cert_dir': '/etc/ssl/certs',
-        'key_dir': '/etc/ssl/private',
-        'pkgs': [ 'ca-certificates', 'ssl-cert' ],
-        'cert_user': 'root',
-        'key_user': 'root',
-        'cert_group': 'root',
-        'key_group': 'ssl-cert',
-        'cert_mode': 644,
-        'key_mode': 640,
-    },
     'RedHat': {
         'cert_dir': '/etc/pki/tls/certs',
         'key_dir': '/etc/pki/tls/private',
@@ -43,6 +32,6 @@
         'cert_group': 'root',
         'key_group': 'ssl-cert',
         'cert_mode': 644,
-        'key_mode': 640,
+        'key_mode': 600,
    },
 }, grain='os_family', merge=salt['pillar.get']('cert:lookup')) %}

--- a/cert/map.jinja
+++ b/cert/map.jinja
@@ -44,5 +44,5 @@
         'key_group': 'ssl-cert',
         'cert_mode': 644,
         'key_mode': 640,
-
+   },
 }, grain='os', merge=salt['pillar.get']('cert:lookup')) %}

--- a/cert/map.jinja
+++ b/cert/map.jinja
@@ -45,4 +45,4 @@
         'cert_mode': 644,
         'key_mode': 640,
    },
-}, grain='os', merge=salt['pillar.get']('cert:lookup')) %}
+}, grain='os_family', merge=salt['pillar.get']('cert:lookup')) %}

--- a/cert/map.jinja
+++ b/cert/map.jinja
@@ -30,7 +30,7 @@
         'cert_user': 'root',
         'key_user': 'root',
         'cert_group': 'root',
-        'key_group': 'ssl-cert',
+        'key_group': 'root',
         'cert_mode': 644,
         'key_mode': 600,
    },


### PR DESCRIPTION
Added redhat support, and switched the map.jinja to look for OS Family rather than
just OS like other maps (redhat is splintered into lovely bits like centos, scientific linux, redhat, etc etc)
