### PR TITLE
Option to override default cert source directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,4 +23,4 @@ Deploys given certificates and keys.
 Example
 =======
 
-Put certificates to  */srv/salt/files/cert/* or any other *cert* directory under file_roots and list them in pillar. Private keys are deployed via pillar. See *cert/pillar.example*.
+Put certificates to  */srv/salt/files/cert/* or any other *cert* directory under file_roots (this configuration can be changed with pillar) and list them in pillar. Private keys are deployed via pillar. See *cert/pillar.example*.

--- a/cert/init.sls
+++ b/cert/init.sls
@@ -33,7 +33,7 @@ cert_packages:
     - contents: |
 {{ cert|indent(8, True) }}
 {% else %}
-    - source: salt://cert/{{ name }}
+    - source: {{ map.cert_source_dir }}{{ name }}
 {% endif %}
     - user: {{ cert_user }}
     - group: {{ cert_group }}

--- a/cert/map.jinja
+++ b/cert/map.jinja
@@ -2,6 +2,7 @@
     'default': {
         'cert_dir': '/etc/ssl/certs',
         'key_dir': '/etc/ssl/private',
+        'cert_source_dir': 'salt://cert/',
         'cert_user': 'root',
         'key_user': 'root',
         'cert_group': 'root',

--- a/cert/map.jinja
+++ b/cert/map.jinja
@@ -1,10 +1,7 @@
 {% set map = salt['grains.filter_by']({
-    'Arch': {
+    'default': {
         'cert_dir': '/etc/ssl/certs',
         'key_dir': '/etc/ssl/private',
-        'pkgs': [ 'ca-certificates', 
-                  'ca-certificates-mozilla',
-                  'ca-certificates-utils',],
         'cert_user': 'root',
         'key_user': 'root',
         'cert_group': 'root',
@@ -12,37 +9,25 @@
         'cert_mode': 644,
         'key_mode': 600,
     },
+    'Arch': {
+        'pkgs': [ 'ca-certificates',
+                  'ca-certificates-mozilla',
+                  'ca-certificates-utils',],
+    },
     'Debian': {
-        'cert_dir': '/etc/ssl/certs',
-        'key_dir': '/etc/ssl/private',
         'pkgs': [ 'ca-certificates', 'ssl-cert' ],
-        'cert_user': 'root',
-        'key_user': 'root',
-        'cert_group': 'root',
         'key_group': 'ssl-cert',
-        'cert_mode': 644,
         'key_mode': 640,
     },
     'RedHat': {
         'cert_dir': '/etc/pki/tls/certs',
         'key_dir': '/etc/pki/tls/private',
         'pkgs': [ 'ca-certificates' ],
-        'cert_user': 'root',
-        'key_user': 'root',
-        'cert_group': 'root',
-        'key_group': 'root',
-        'cert_mode': 644,
-        'key_mode': 600,
    },
     'Suse': {
         'cert_dir': '/etc/ssl/certs',
         'key_dir': '/etc/ssl/private',
         'pkgs': [ 'ca-certificates', 'ca-certificates-mozilla'],
-        'cert_user': 'root',
-        'key_user': 'root',
-        'cert_group': 'root',
-        'key_group': 'root',
         'cert_mode': '444',
-        'key_mode': '600',
     },
-}, grain='os_family', merge=salt['pillar.get']('cert:lookup')) %}
+}, grain='os_family', merge=salt['pillar.get']('cert:lookup'), base='default') %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,8 @@
 cert:
+  # use lookup section to override 'map.jinja' values
+  #lookup:
+    # define source directory for certs
+    #cert_source_dir: salt://files/certs/
   certlist:
     name_of_cert:
       key: |


### PR DESCRIPTION
Hi,

this PR modify the formula to allow overriding the default cert source directory, which was salt://cert/ and not changeable. The default behaviour stays the same.
See #6 