### PR TITLE
support makedirs

### DIFF
--- a/cert/init.sls
+++ b/cert/init.sls
@@ -35,6 +35,7 @@ cert_packages:
 {% else %}
     - source: {{ map.cert_source_dir }}{{ name }}
 {% endif %}
+    - makedirs: True
     - user: {{ cert_user }}
     - group: {{ cert_group }}
     - mode: {{ cert_mode }}
@@ -44,6 +45,7 @@ cert_packages:
   file.managed:
     - contents: |
 {{ key|indent(8, True) }}
+    - makedirs: True
     - user: {{ key_user }}
     - group: {{ key_group }}
     - mode: {{ key_mode }}


### PR DESCRIPTION
Supported in lookup, or per certificate

Allow to deploy certificate for services without placing them in already existing directories.