### PR TITLE
little fix on certificate state ID so no double slash is generated

### DIFF
--- a/cert/map.jinja
+++ b/cert/map.jinja
@@ -21,7 +21,7 @@
         'pkgs': [ 'ca-certificates', 'ssl-cert' ],
         'key_group': 'ssl-cert',
         'key_mode': 640,
-        'cert_dir': '/usr/local/share/ca-certificates/',
+        'cert_dir': '/usr/local/share/ca-certificates',
     },
     'RedHat': {
         'cert_dir': '/etc/pki/tls/certs',


### PR DESCRIPTION
Just a quick fix to solve #19