### PR TITLE
Adds support for specifying the certificate or key file name extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# salt-formula-cert
+
+Salt formula for deploying certificates
+Forked from here:  https://github.com/saltstack-formulas/cert-formula

--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-# salt-formula-cert
-
-Salt formula for deploying certificates
-Forked from here:  https://github.com/saltstack-formulas/cert-formula

--- a/cert/init.sls
+++ b/cert/init.sls
@@ -24,7 +24,7 @@ cert_packages:
   {% set key = data.get('key', False) %}
   {% set cert_ext = data.get('cert_ext', map.cert_ext) %}
   {% set key_ext = data.get('key_ext', map.key_ext) %}
-  {% set cert_user = data.get('cert_user', map.cert_user) %}  
+  {% set cert_user = data.get('cert_user', map.cert_user) %}
   {% set key_user = data.get('key_user', map.key_user) %}
   {% set cert_group = data.get('cert_group', map.cert_group) %}
   {% set key_group = data.get('key_group', map.key_group) %}

--- a/cert/init.sls
+++ b/cert/init.sls
@@ -22,7 +22,9 @@ cert_packages:
 
   {% set cert = data.get('cert', False) %}
   {% set key = data.get('key', False) %}
-  {% set cert_user = data.get('cert_user', map.cert_user) %}
+  {% set cert_ext = data.get('cert_ext', map.cert_ext) %}
+  {% set key_ext = data.get('key_ext', map.key_ext) %}
+  {% set cert_user = data.get('cert_user', map.cert_user) %}  
   {% set key_user = data.get('key_user', map.key_user) %}
   {% set cert_group = data.get('cert_group', map.cert_group) %}
   {% set key_group = data.get('key_group', map.key_group) %}
@@ -31,19 +33,19 @@ cert_packages:
   {% set cert_dir = data.get('cert_dir', map.cert_dir) %}
   {% set key_dir = data.get('key_dir', map.key_dir) %}
   {% set remove = data.get('remove', map.remove) %}
-
-{{ cert_dir }}/{{ name }}.crt:
+  
+{{ cert_dir }}/{{ name }}{{ cert_ext }}:
   {% if remove %}
   file.absent:
     - onlyif:
-      - "test -e {{ cert_dir }}/{{ name }}.crt"
+      - "test -e {{ cert_dir }}/{{ name }}{{ cert_ext }}"
   {% else %}
   file.managed:
     {% if cert %}
     - contents: |
 {{ cert|indent(8, True) }}
     {% else %}
-    - source: {{ map.cert_source_dir }}{{ name }}.crt
+    - source: {{ map.cert_source_dir }}{{ name }}{{ cert_ext }}
     {% endif %}
     - makedirs: True
     - user: {{ cert_user }}
@@ -56,11 +58,11 @@ cert_packages:
   {% endif %}
 
   {% if key %}
-{{ key_dir }}/{{ name }}.key:
+{{ key_dir }}/{{ name }}{{ key_ext }}:
     {% if remove %}
   file.absent:
     - onlyif:
-      - "test -e {{ key_dir }}/{{ name }}.key"
+      - "test -e {{ key_dir }}/{{ name }}{{ key_ext }}"
     {% else %}
   file.managed:
     - contents: |

--- a/cert/init.sls
+++ b/cert/init.sls
@@ -33,7 +33,7 @@ cert_packages:
   {% set cert_dir = data.get('cert_dir', map.cert_dir) %}
   {% set key_dir = data.get('key_dir', map.key_dir) %}
   {% set remove = data.get('remove', map.remove) %}
-  
+
 {{ cert_dir }}/{{ name }}{{ cert_ext }}:
   {% if remove %}
   file.absent:

--- a/cert/map.jinja
+++ b/cert/map.jinja
@@ -4,6 +4,8 @@
         'key_dir': '/etc/ssl/private',
         'cert_source_dir': 'salt://cert/',
         'cert_tmp_dir': '/tmp/certs/',
+        'cert_ext': '.crt',
+        'key_ext': '.key',
         'cert_user': 'root',
         'key_user': 'root',
         'cert_group': 'root',

--- a/pillar.example
+++ b/pillar.example
@@ -23,6 +23,8 @@ cert:
       key_mode: 640
       cert_dir: /etc/ssl/certs/
       key_dir: /etc/ssl/private
+      cert_ext: .crt  # The default certificate and key file extension values
+      key_ext: .key   # are known to work. Changing them must be done carefully
     name_of_4th_cert: {} # cert has no private key to deploy
     name_of_cert_you_want_removed:
       remove: True # will remove cert and key with this name!

--- a/test/integration/controls/managed.rb
+++ b/test/integration/controls/managed.rb
@@ -27,7 +27,7 @@ control 'managed' do
     its('content') { should match /^1MOCKED CERT AND KEY/ }
     its('content') { should match /^-----END RSA PRIVATE KEY-----/ }
   end
-  describe file(key_dir + 'cert.and.key.with.ext.to.add.pem') do
+  describe file(cert_dir + 'cert.and.key.with.ext.to.add.pem') do
     its('content') { should match /^-----BEGIN CERTIFICATE-----/ }
     its('content') { should match /^4MOCKED CERT AND KEY/ }
     its('content') { should match /^-----END CERTIFICATE-----/ }

--- a/test/integration/controls/managed.rb
+++ b/test/integration/controls/managed.rb
@@ -27,6 +27,16 @@ control 'managed' do
     its('content') { should match /^1MOCKED CERT AND KEY/ }
     its('content') { should match /^-----END RSA PRIVATE KEY-----/ }
   end
+  describe file(key_dir + 'cert.and.key.with.ext.to.add.pem') do
+    its('content') { should match /^-----BEGIN CERTIFICATE-----/ }
+    its('content') { should match /^4MOCKED CERT AND KEY/ }
+    its('content') { should match /^-----END CERTIFICATE-----/ }
+  end
+  describe file(key_dir + 'cert.and.key.with.ext.to.add.priv') do
+    its('content') { should match /^-----BEGIN RSA PRIVATE KEY-----/ }
+    its('content') { should match /^4MOCKED CERT AND KEY/ }
+    its('content') { should match /^-----END RSA PRIVATE KEY-----/ }
+  end
   describe file(cert_dir + 'cert.to.add.crt') do
     its('content') { should match /^-----BEGIN CERTIFICATE-----/ }
     its('content') { should match /^2MOCKED CERT/ }

--- a/test/integration/pillar/managed.sls
+++ b/test/integration/pillar/managed.sls
@@ -27,3 +27,14 @@ cert:
         -----BEGIN RSA PRIVATE KEY-----
         3MOCKED CERT AND KEY
         -----END RSA PRIVATE KEY-----
+    cert.and.key.with.ext.to.add:
+      cert: |
+        -----BEGIN CERTIFICATE-----
+        4MOCKED CERT AND KEY
+        -----END CERTIFICATE-----
+      cert_ext: .pem
+      key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        4MOCKED CERT AND KEY
+        -----END RSA PRIVATE KEY-----
+      key_ext: .priv


### PR DESCRIPTION
We have some existing cert files deployed with the .pem extension.  I have added support to this formula to allow specifying the file extension to accommodate this requirement.  