### PR TITLE
fix(cert): extracted certificate update command into map

### DIFF
--- a/cert/map.jinja
+++ b/cert/map.jinja
@@ -24,11 +24,13 @@
         'key_group': 'ssl-cert',
         'key_mode': 640,
         'cert_dir': '/usr/local/share/ca-certificates',
+        'cert_update_cmd': 'update-ca-certificates --fresh',
     },
     'RedHat': {
         'cert_dir': '/etc/pki/tls/certs',
         'key_dir': '/etc/pki/tls/private',
         'pkgs': [ 'ca-certificates' ],
+        'cert_update_cmd': 'update-ca-trust extract',
    },
     'Suse': {
         'cert_dir': '/etc/ssl/certs',


### PR DESCRIPTION
Currently, changes to certificates are not applied on RedHat systems.  This change extracts the command into the jinja map, and adds the command for RedHat machines, while preserving the command for Debian machines and providing flexibility for adding commands for other systems.