### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/pillar/managed.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -1,8 +1,11 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 cert:
-  # use lookup section to override 'map.jinja' values
-  #lookup:
-    # define source directory for certs
-    #cert_source_dir: salt://files/certs/
+  # # use lookup section to override 'map.jinja' values
+  # lookup:
+  #   # define source directory for certs
+  #   cert_source_dir: salt://files/certs/
   certlist:
     name_of_cert:
       key: |
@@ -25,12 +28,12 @@ cert:
       key_dir: /etc/ssl/private
       cert_ext: .crt  # The default certificate and key file extension values
       key_ext: .key   # are known to work. Changing them must be done carefully
-    name_of_4th_cert: {} # cert has no private key to deploy
+    name_of_4th_cert: {}  # cert has no private key to deploy
     name_of_cert_you_want_removed:
-      remove: True # will remove cert and key with this name!
+      remove: true  # will remove cert and key with this name!
       key: |
         KEY HERE
       cert: |
         CERT HERE
       cert_dir: /usr/local/share/ca-certificates
-      key_dir: /etc/ssl/private 
+      key_dir: /etc/ssl/private

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: cert formula
 maintainer: SaltStack Formulas

--- a/test/salt/pillar/managed.sls
+++ b/test/salt/pillar/managed.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 cert:
   lookup:
     cert_source_dir: /tmp/kitchen/srv/salt/files/
@@ -18,7 +21,7 @@ cert:
         2MOCKED CERT
         -----END CERTIFICATE-----
     cert.and.key.to.remove:
-      remove: True
+      remove: true
       cert: |
         -----BEGIN CERTIFICATE-----
         3MOCKED CERT AND KEY

--- a/test/salt/pillar/no_certs.sls
+++ b/test/salt/pillar/no_certs.sls
@@ -1,4 +1,0 @@
-# -*- coding: utf-8 -*-
-# vim: ft=yaml
----
-cert: {}

--- a/test/salt/pillar/no_certs.sls
+++ b/test/salt/pillar/no_certs.sls
@@ -1,1 +1,4 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 cert: {}


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
cert-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
pillar.example
  1:1       warning  missing document start "---"  (document-start)
  3:4       warning  missing starting space in comment  (comments)
  4:5       warning  comment not indented like content  (comments-indentation)
  5:6       warning  missing starting space in comment  (comments)
  28:26     warning  too few spaces before comment  (comments)
  30:15     warning  truthy value should be one of [false, true]  (truthy)
  30:20     warning  too few spaces before comment  (comments)
  36:33     error    no new line character at the end of file  (new-line-at-end-of-file)
  36:32     error    trailing spaces  (trailing-spaces)

test/salt/pillar/managed.sls
  1:1       warning  missing document start "---"  (document-start)
  21:15     warning  truthy value should be one of [false, true]  (truthy)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.